### PR TITLE
Funnel tests through the command line

### DIFF
--- a/bin/okapi
+++ b/bin/okapi
@@ -1,38 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'clamp'
-require 'okapi'
-require 'uri'
 
-class Okapi::Main < Clamp::Command
-  option "--url", "URL",  "use okapi cluster at URL", default: URI("https://okapi.frontside.io") do |url|
-    URI(url)
-  end
-  option "--tenant", "TENANT",  "connect using this tenant" do |url|
-    URI(url)
-  end
+require 'okapi/cli'
 
-  option "--token", "TOKEN", "authenticate requests with TOKEN"
-
-  def execute
-    puts "main"
-  end
-
-  subcommand "login", "authenticate to okapi and store credentials" do
-    def execute
-      puts "login: #{client.inspect}"
-    end
-  end
-  subcommand "logout", "destroy existing credentials" do
-    def execute
-      puts "logout"
-    end
-  end
-
-  def client
-    Okapi::Client.new(url, tenant, token)
-  end
-
-end
-
-Okapi::Main.run
+puts Okapi::CLI.run

--- a/fixtures/vcr_cassettes/okapi-cli-specs.yml
+++ b/fixtures/vcr_cassettes/okapi-cli-specs.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/_/proxy/modules
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.3
+      Date:
+      - Thu, 05 Oct 2017 21:53:45 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "id" : "folio-mod-configuration",
+          "name" : "Configuration"
+        }, {
+          "id" : "mod-kb-ebsco-7c3d2a6d65d7791a936ba754f72a133e891dbddf",
+          "name" : "kb-ebsco"
+        }, {
+          "id" : "folio-mod-auth-token",
+          "name" : "authtoken"
+        }, {
+          "id" : "folio-mod-circulation",
+          "name" : "Circulation Module"
+        }, {
+          "id" : "folio-mod-permissions",
+          "name" : "permissions"
+        }, {
+          "id" : "folio-mod-inventory-storage",
+          "name" : "Inventory Storage Module"
+        }, {
+          "id" : "folio-mod-login",
+          "name" : "login"
+        }, {
+          "id" : "folio-mod-users",
+          "name" : "users"
+        }, {
+          "id" : "folio-mod-inventory",
+          "name" : "Inventory Module"
+        }, {
+          "id" : "folio-mod-circulation-storage",
+          "name" : "Circulation Storage Module"
+        }, {
+          "id" : "folio-mod-users-bl",
+          "name" : "users business logic"
+        } ]
+    http_version: 
+  recorded_at: Thu, 05 Oct 2017 21:53:45 GMT
+recorded_with: VCR 3.0.3

--- a/lib/okapi/cli.rb
+++ b/lib/okapi/cli.rb
@@ -1,0 +1,53 @@
+require "okapi"
+require "clamp"
+
+module Okapi
+  class CLI < Clamp::Command
+    option "--config", "CONFIG_FILE", "use persistent configuration from this file"
+    option "--url", "URL",  "use okapi cluster at URL"
+    option "--tenant", "TENANT",  "connect using this tenant"
+    option "--token", "TOKEN", "authenticate requests with TOKEN"
+
+    subcommand "config:set", "set the CLI configuration variable {OKAPI_URL, OKAPI_TENANT, OKAPI_TOKEN}" do
+      def model
+
+      end
+    end
+
+    subcommand "configurations:index", "get a list of configuration entries for this client" do
+      def model
+        client.user.configuration.entries.index
+      end
+    end
+
+    subcommand "login", "authenticate to okapi and store credentials" do
+      def model
+        client.tenant.login.login.create
+      end
+    end
+
+    subcommand "logout", "destroy existing credentials" do
+      def execute
+        puts "logout"
+      end
+    end
+
+    subcommand "modules:index", "show a listing of all installed modules" do
+      def model
+        client.modules
+      end
+    end
+
+    def client
+      Okapi::Client.new(settings)
+    end
+
+    def execute
+      JSON.pretty_generate model
+    end
+
+    def settings
+      Settings.new(url, tenant, token)
+    end
+  end
+end

--- a/lib/okapi/settings.rb
+++ b/lib/okapi/settings.rb
@@ -1,0 +1,40 @@
+module Okapi
+  class Settings
+    def initialize(url, tenant, token)
+      @url = url
+      @tenant = tenant
+      @token = token
+    end
+    def url
+      ENV['OKAPI_URL'] || @url or raise ConfigurationError, <<-EOM
+this operation requires the url of your Okapi gateway, but it couldn't be found.
+
+You can fix this by setting either the `OKAPI_URL` environment variable, or
+using the `--url` option if you're using the command line.
+--
+EOM
+      URI(ENV['OKAPI_URL'] || @url)
+    end
+
+    def tenant
+      ENV['OKAPI_TENANT'] || @tenant or raise ConfigurationError, <<-EOM
+this operation requires a tenant id, but it couldn't be found.
+
+You can fix this by setting either the `OKAPI_TENANT` environment variable, or
+using the `--tenant` option if you're using the command line.
+EOM
+    end
+
+    def token
+      ENV['OKAPI_TOKEN'] || @token or raise ConfigurationError, <<-EOM
+this operation requires you to be logged in, and already authenticated with
+your Okapi cluster.
+
+You can fix this by obtaining an authenication token, and then using it by
+either setting the `OKAPI_TOKEN` environment variable or using the
+`--token` option from the command line.
+EOM
+    end
+  end
+
+end

--- a/lib/okapi/settings.rb
+++ b/lib/okapi/settings.rb
@@ -6,18 +6,18 @@ module Okapi
       @token = token
     end
     def url
-      ENV['OKAPI_URL'] || @url or raise ConfigurationError, <<-EOM
+      get_var!(:url, <<~EOM) do |url|
 this operation requires the url of your Okapi gateway, but it couldn't be found.
 
 You can fix this by setting either the `OKAPI_URL` environment variable, or
 using the `--url` option if you're using the command line.
---
 EOM
-      URI(ENV['OKAPI_URL'] || @url)
+        URI(url)
+      end
     end
 
     def tenant
-      ENV['OKAPI_TENANT'] || @tenant or raise ConfigurationError, <<-EOM
+      get_var!(:tenant, <<~EOM)
 this operation requires a tenant id, but it couldn't be found.
 
 You can fix this by setting either the `OKAPI_TENANT` environment variable, or
@@ -26,7 +26,7 @@ EOM
     end
 
     def token
-      ENV['OKAPI_TOKEN'] || @token or raise ConfigurationError, <<-EOM
+      get_var!(:token, <<~EOM)
 this operation requires you to be logged in, and already authenticated with
 your Okapi cluster.
 
@@ -34,6 +34,19 @@ You can fix this by obtaining an authenication token, and then using it by
 either setting the `OKAPI_TOKEN` environment variable or using the
 `--token` option from the command line.
 EOM
+    end
+
+    def get_var!(symbol, error_msg)
+      env_var_name = "OKAPI_#{symbol.to_s.upcase}"
+      env_value = ENV[env_var_name]
+      instance_value = instance_variable_get("@#{symbol}")
+      if !env_value.nil? && !env_value.trim.empty?
+        block_given? ? yield(env_value) : env_value
+      elsif instance_value
+        block_given? ? yield(instance_value) : instance_value
+      else
+        raise ConfigurationError, error_msg
+      end
     end
   end
 

--- a/okapi.gemspec
+++ b/okapi.gemspec
@@ -35,4 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "vcr", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 3.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "okapi"
+require "vcr"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -11,4 +12,9 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+end
+
+VCR.configure do |config|
+  config.cassette_library_dir = "fixtures/vcr_cassettes"
+  config.hook_into :webmock
 end


### PR DESCRIPTION
We want to ship a command line along with this ruby library.

This change makes the test cases flow throw the CLI so that we get to

a) test that the cli is working
b) consume the client api to see if it's good or not.

In terms of validating which data is necessary for each request, all of the inputs for the client have been concentrated into a `Settings` object. The idea being that if any code _asks_ for a setting that isn't there, that's when it should blow up. Laziness FTW.  For example, if through fulfilling a request, you need to ask the settings for the token, then by definition the token must be set. On the other hand, if you _don't_ need a token, then the code will never actually validate that you have one.