### PR TITLE
Make command line options take precedence over env vars.

### DIFF
--- a/lib/okapi/settings.rb
+++ b/lib/okapi/settings.rb
@@ -40,10 +40,10 @@ EOM
       env_var_name = "OKAPI_#{symbol.to_s.upcase}"
       env_value = ENV[env_var_name]
       instance_value = instance_variable_get("@#{symbol}")
-      if !env_value.nil? && !env_value.strip.empty?
-        block_given? ? yield(env_value) : env_value
-      elsif instance_value
+      if instance_value && !instance_value.strip.empty?
         block_given? ? yield(instance_value) : instance_value
+      elsif !env_value.nil? && !env_value.strip.empty?
+        block_given? ? yield(env_value) : env_value
       else
         raise ConfigurationError, error_msg
       end


### PR DESCRIPTION
If you specify something via the command line:

```
folio --url https://my-okapi.my-server.com modules:index
```

That option should take precedence over any `OKAPI_URL` environment value that is set when the command is run.

Right now, the ENV value takes precedence, but this swaps it so that an explicit command line option, if present, will override the environment setting.