### PR TITLE
ignore tpm test files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 # rspec failure tracking
 .rspec_status
 /.ruby-version
+/spec/sandbox


### PR DESCRIPTION
As part of the build, we set the homedir equal to `spec/sandbox/home`. This is just a temporary artifact that can safely be ignored.