### PR TITLE
Implement login, logout, and *:get commands

### DIFF
--- a/bin/okapi
+++ b/bin/okapi
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
-
-
+require 'bundler/setup'
 require 'okapi/cli'
 
 puts Okapi::CLI.run

--- a/lib/okapi.rb
+++ b/lib/okapi.rb
@@ -59,7 +59,7 @@ module Okapi
         RequestError.maybe_fail! response
         json = JSON.parse(response.body)
         if block_given?
-          yield json
+          yield json, response
         else
           json
         end

--- a/okapi.gemspec
+++ b/okapi.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "clamp", "~> 1.1"
+  spec.add_dependency "highline", "~> 1.7"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/fixtures/vcr_cassettes/okapi-cli-specs.yml
+++ b/spec/fixtures/vcr_cassettes/okapi-cli-specs.yml
@@ -19,54 +19,314 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.13.3
+      - nginx/1.13.5
       Date:
-      - Thu, 05 Oct 2017 21:53:45 GMT
+      - Mon, 09 Oct 2017 19:36:52 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      X-Okapi-Trace:
+      - 'GET okapi-2.0.0 /_/proxy/modules : 200'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains;
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "id" : "folio-mod-configuration",
-          "name" : "Configuration"
+          "id" : "okapi-2.0.0",
+          "name" : "okapi-2.0.0"
         }, {
-          "id" : "mod-kb-ebsco-7c3d2a6d65d7791a936ba754f72a133e891dbddf",
-          "name" : "kb-ebsco"
+          "id" : "mod-users-bl-2.1.1-SNAPSHOT",
+          "name" : "users business logic"
         }, {
-          "id" : "folio-mod-auth-token",
-          "name" : "authtoken"
-        }, {
-          "id" : "folio-mod-circulation",
-          "name" : "Circulation Module"
-        }, {
-          "id" : "folio-mod-permissions",
-          "name" : "permissions"
-        }, {
-          "id" : "folio-mod-inventory-storage",
-          "name" : "Inventory Storage Module"
-        }, {
-          "id" : "folio-mod-login",
-          "name" : "login"
-        }, {
-          "id" : "folio-mod-users",
+          "id" : "mod-users-14.2.0",
           "name" : "users"
         }, {
-          "id" : "folio-mod-inventory",
-          "name" : "Inventory Module"
+          "id" : "mod-permissions-5.0.1-SNAPSHOT",
+          "name" : "permissions"
         }, {
-          "id" : "folio-mod-circulation-storage",
-          "name" : "Circulation Storage Module"
+          "id" : "mod-login-4.0.1-SNAPSHOT",
+          "name" : "login"
         }, {
-          "id" : "folio-mod-users-bl",
-          "name" : "users business logic"
+          "id" : "mod-kb-ebsco-0.1.0",
+          "name" : "kb-ebsco"
+        }, {
+          "id" : "mod-configuration-3.0.1-SNAPSHOT",
+          "name" : "Configuration"
+        }, {
+          "id" : "mod-authtoken-1.0.1-SNAPSHOT",
+          "name" : "authtoken"
         } ]
-    http_version: 
-  recorded_at: Thu, 05 Oct 2017 21:53:45 GMT
+    http_version:
+  recorded_at: Mon, 09 Oct 2017 19:36:52 GMT
+- request:
+    method: post
+    uri: https://okapi.frontside.io/authn/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"username","password":"password"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 09 Oct 2017 19:39:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'POST mod-authtoken-1.0.1-SNAPSHOT http://10.15.251.168:80/authn/login : 202'
+      - 'POST mod-login-4.0.1-SNAPSHOT http://10.15.241.175:80/authn/login : 201 186493us'
+      X-Okapi-Token:
+      - <OKAPI_TEST_TOKEN>
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.7
+      X-Forwarded-For:
+      - 10.128.0.7
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/authn/login"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/authn/login"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 899400/authn
+      X-Okapi-Url:
+      - http://10.15.254.182:80
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.0.1-SNAPSHOT":["perms.users.get"],"mod-login-4.0.1-SNAPSHOT":["auth.signtoken","users.collection.get"]}'
+      X-Okapi-Permissions:
+      - "[]"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "username" : "username",
+          "password" : "password"
+        }
+    http_version:
+  recorded_at: Mon, 09 Oct 2017 19:39:39 GMT
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - <OKAPI_TEST_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 09 Oct 2017 19:39:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.0.1-SNAPSHOT http://10.15.251.168:80/configurations/entries
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT http://10.15.255.252:80/configurations/entries
+        : 200 80141us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.7
+      X-Forwarded-For:
+      - 10.128.0.7
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 336068/configurations
+      X-Okapi-Url:
+      - http://10.15.254.182:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.0.1-SNAPSHOT":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - <OKAPI_TEST_TOKEN>
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "5c09a96f-868d-4956-bdc1-1d3299bb9a4c",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.timezone.en",
+            "description" : "timezone",
+            "default" : true,
+            "enabled" : true,
+            "value" : "GMT-04:00"
+          }, {
+            "id" : "2bf53c72-9d02-49bc-907c-2a1430f6db02",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.timezone.en",
+            "description" : "timezone",
+            "default" : true,
+            "enabled" : true,
+            "value" : "GMT-04:00",
+            "userId" : "joeshmoe"
+          }, {
+            "id" : "e9872515-aefb-4291-b0f9-1c299243088c",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.timezone_date.en",
+            "description" : "timezone date format",
+            "default" : true,
+            "enabled" : true,
+            "value" : "dd/MM/yyyy"
+          }, {
+            "id" : "5cdec2ba-47b0-4fd4-bde7-1977de817219",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.timezone_time.en",
+            "description" : "timezone time format",
+            "default" : true,
+            "enabled" : true,
+            "value" : "HH:mm:ss a z"
+          }, {
+            "id" : "c4edeb57-e2b6-43f9-b3a4-02dc3148eeaf",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.currency_code.en",
+            "description" : "currency",
+            "default" : true,
+            "enabled" : true,
+            "value" : "USD"
+          }, {
+            "id" : "d8cf9959-0c97-4616-86cb-9f9332124bea",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.currency_symbol.en",
+            "description" : "currency code",
+            "default" : true,
+            "enabled" : true,
+            "value" : "$"
+          }, {
+            "id" : "b60b0527-88cc-481f-962b-9d4f902a74ca",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.timezone.dk",
+            "description" : "timezone",
+            "default" : false,
+            "enabled" : true,
+            "value" : "GMT-01:00"
+          }, {
+            "id" : "46c36ef2-25b8-4434-bc1c-4f180527d255",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.timezone_date.dk",
+            "description" : "timezone date format",
+            "default" : false,
+            "enabled" : true,
+            "value" : "MM/dd/yyyy"
+          }, {
+            "id" : "2ccd3683-0ec1-45b7-922f-7ee422236301",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.timezone_time.dk",
+            "description" : "timezone time format",
+            "default" : false,
+            "enabled" : true,
+            "value" : "HH:mm:ss a z"
+          }, {
+            "id" : "734d35a1-ebe2-4b42-8fc0-00b4e12a2ede",
+            "module" : "SETTINGS",
+            "configName" : "locale",
+            "code" : "system.currency_code.dk",
+            "description" : "currency",
+            "default" : false,
+            "enabled" : true,
+            "value" : "DKK"
+          } ],
+          "totalRecords" : 13,
+          "resultInfo" : {
+            "totalRecords" : 13,
+            "facets" : [ ]
+          }
+        }
+    http_version:
+  recorded_at: Mon, 09 Oct 2017 19:39:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/okapi_spec.rb
+++ b/spec/okapi_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Okapi do
   let(:modules) { JSON.parse okapi "--url https://okapi.frontside.io modules:index" }
 
   it "can get a list of modules" do
-    expect(modules.length).to be(11)
-    expect(modules.first["id"]).to eq("folio-mod-configuration")
+    expect(modules.length).to be(8)
+    expect(modules.first["id"]).to eq("okapi-2.0.0")
   end
 
   it "blows up when trying to access an endpoint as a tenant, but no tenant id is specified" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,4 +37,5 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   config.hook_into :webmock
+  config.filter_sensitive_data("<OKAPI_TEST_TOKEN>") { ENV["OKAPI_TEST_TOKEN"] }
 end


### PR DESCRIPTION
- `login` - will prompt for a username and password then save the returned token to the configuration file.

    ```
    $ okapi login
    username:
    password:
    ```
- `logout` - will delete the token from the configuration file.

    ```
    $ okapi logout
    ```
- `get` - will perform a `GET` request to any Okapi endpoint. 

    ```
    $ okapi get /_/proxy/tenants
    ```
- `tenant:get` - will perform a `GET` request with the `X-Okapi-Tenant` header.

    ```
    $ okapi tenant:get /configurations/entries
    ```
- `user:get` - will perform a `GET` request with `X-Okapi-Tenant` **_and_** `X-Okapi-Token` headers.

    ```
    $ okapi user:get /authn/credentials
    ```

To obfuscate the token returned by Okapi during the VCR recording, VCR is configured to use an environment variable `OKAPI_TEST_TOKEN`. This token is purposefully named `_TEST_` to prevent it from being used as the `token` setting when settings are inferred from environment variables.

While the tests will still pass when `OKAPI_TEST_TOKEN` is empty or `nil`, Travis has been configured with the token generated when logging into our cluster as the admin user.