### PR TITLE
Display default configuration file location.

### DIFF
--- a/lib/okapi/cli/config.rb
+++ b/lib/okapi/cli/config.rb
@@ -11,6 +11,10 @@ module Okapi
     def filename
       File.join(Dir.home, ".okapi")
     end
+
+    def inspect
+      filename
+    end
   end
 
   class ExplicitConfig


### PR DESCRIPTION
Clamp uses the 'inspect' method to display a default argument to the
user. However, in our case, when this is an object, it makes the
output look like `#<Okapi::ImplicitConfig:0x00007fc7849108e0>` This
makes the config point out the location of its config. so that it will
be something like `/Users/cowboyd/.okapi`

*Before*
```
Options:
    --config CONFIG_FILE          use persistent configuration from this file (default: #<Okapi::ImplicitConfig:0x007fd8782635d8>)
    --url URL                     use okapi cluster at URL
    --tenant TENANT               connect using this tenant
    --token TOKEN                 authenticate requests with TOKEN
    -h, --help                    print help
```

*After*
```
Options:
    --config CONFIG_FILE          use persistent configuration from this file (default: /Users/cowboyd/.okapi)
    --url URL                     use okapi cluster at URL
    --tenant TENANT               connect using this tenant
    --token TOKEN                 authenticate requests with TOKEN
    -h, --help                    print help
```