### PR TITLE
Default commands to include the user token and tenant

### DIFF
--- a/lib/okapi/cli.rb
+++ b/lib/okapi/cli.rb
@@ -69,7 +69,7 @@ module Okapi
       end
     end
 
-    subcommand "get", "issue a GET request to the spcified PATH" do
+    subcommand "show", "issue a GET request to the spcified PATH" do
       parameter "PATH", "PATH of the resource to get"
 
       def model

--- a/lib/okapi/cli.rb
+++ b/lib/okapi/cli.rb
@@ -11,6 +11,8 @@ module Okapi
     option "--url", "URL",  "use okapi cluster at URL"
     option "--tenant", "TENANT",  "connect using this tenant"
     option "--token", "TOKEN", "authenticate requests with TOKEN"
+    option "--no-tenant", :flag, "perform the request without a tenant or user token"
+    option "--no-user", :flag, "perform the request without the user token"
 
     subcommand "config", "show all configured variables" do
       def model
@@ -67,27 +69,11 @@ module Okapi
       end
     end
 
-    subcommand "get", "issue a GET request" do
-      parameter "PATH", "PATH to fetch from the api"
+    subcommand "get", "issue a GET request to the spcified PATH" do
+      parameter "PATH", "PATH of the resource to get"
 
       def model
         client.get path
-      end
-    end
-
-    subcommand "tenant:get", "issue a GET request as a Tenant" do
-      parameter "PATH", "PATH to fetch from the api"
-
-      def model
-        client.tenant.get path
-      end
-    end
-
-    subcommand "user:get", "issue a GET request as a User" do
-      parameter "PATH", "PATH to fetch from the api"
-
-      def model
-        client.user.get path
       end
     end
 
@@ -95,7 +81,7 @@ module Okapi
       parameter "PATH", "PATH of the resource collection in which the create will happen"
 
       def model
-        client.user.post path, JSON.parse($stdin.read)
+        client.post path, JSON.parse($stdin.read)
       end
     end
 
@@ -103,7 +89,7 @@ module Okapi
       parameter "PATH", "PATH of the resource to delete"
 
       def model
-        client.user.delete path
+        client.delete path
         "Successfully deleted #{path}"
       end
     end
@@ -116,7 +102,15 @@ module Okapi
 
     def client
       variables.load!
-      Okapi::Client.new(url, tenant, token)
+      anonymous = Okapi::Client.new(url, tenant, token)
+
+      if no_tenant?
+        anonymous
+      elsif no_user?
+        anonymous.tenant
+      else
+        anonymous.user
+      end
     end
 
     def execute

--- a/spec/okapi_spec.rb
+++ b/spec/okapi_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe Okapi do
   end
 
   it "blows up when trying to access an endpoint with no user, and no tenant id is specified" do
-    expect{ okapi "--url https://okapi.frontside.io get --no-user /authn/credentials"}.to raise_error(Okapi::ConfigurationError)
+    expect{ okapi "--url https://okapi.frontside.io show --no-user /authn/credentials"}.to raise_error(Okapi::ConfigurationError)
   end
 
   it "blows up when trying to access an endpoint that needs a user, but no auth token is specified" do
-    expect{ okapi "--url https://okapi.frontside.io --tenant fs get /configurations/entries"}.to raise_error(Okapi::ConfigurationError)
+    expect{ okapi "--url https://okapi.frontside.io --tenant fs show /configurations/entries"}.to raise_error(Okapi::ConfigurationError)
   end
 
   it "blows up if you try to specify a configuration file that doesn't exist" do
@@ -87,7 +87,7 @@ RSpec.describe Okapi do
     end
 
     it "uses the saved token to access an endpoint as a user" do
-      expect{okapi "get /configurations/entries"}.to_not raise_error
+      expect{okapi "show /configurations/entries"}.to_not raise_error
     end
 
     describe "creating a resource" do
@@ -105,7 +105,7 @@ RSpec.describe Okapi do
 EOJSON
           @result = JSON.parse okapi "create /configurations/entries"
         end
-        @entry =  JSON.parse okapi "get /configurations/entries/#{@result["id"]}"
+        @entry =  JSON.parse okapi "show /configurations/entries/#{@result["id"]}"
       end
 
       it "stores the JSON" do
@@ -118,7 +118,7 @@ EOJSON
           okapi "destroy /configurations/entries/#{@result["id"]}"
         end
         it "no longer can be found as a resource" do
-          expect{okapi "get /configurations/#{@result["id"]}"}.to raise_error(Okapi::RequestError, /HTTPNotFound/)
+          expect{okapi "show /configurations/#{@result["id"]}"}.to raise_error(Okapi::RequestError, /HTTPNotFound/)
         end
       end
 

--- a/spec/okapi_spec.rb
+++ b/spec/okapi_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe Okapi do
     expect(modules.first["id"]).to eq("permissions-module-4.0.4")
   end
 
-  it "blows up when trying to access an endpoint as a tenant, but no tenant id is specified" do
-    expect{ okapi "--url https://okapi.frontside.io tenant:get /authn/credentials"}.to raise_error(Okapi::ConfigurationError)
+  it "blows up when trying to access an endpoint with no user, and no tenant id is specified" do
+    expect{ okapi "--url https://okapi.frontside.io get --no-user /authn/credentials"}.to raise_error(Okapi::ConfigurationError)
   end
 
-  it "blows up when trying to access an endpoint as a user, but no auth token is specified" do
-    expect{ okapi "--url https://okapi.frontside.io --tenant fs user:get /configurations/entries"}.to raise_error(Okapi::ConfigurationError)
+  it "blows up when trying to access an endpoint that needs a user, but no auth token is specified" do
+    expect{ okapi "--url https://okapi.frontside.io --tenant fs get /configurations/entries"}.to raise_error(Okapi::ConfigurationError)
   end
 
   it "blows up if you try to specify a configuration file that doesn't exist" do
@@ -87,7 +87,7 @@ RSpec.describe Okapi do
     end
 
     it "uses the saved token to access an endpoint as a user" do
-      expect{okapi "user:get /configurations/entries"}.to_not raise_error
+      expect{okapi "get /configurations/entries"}.to_not raise_error
     end
 
     describe "creating a resource" do
@@ -105,7 +105,7 @@ RSpec.describe Okapi do
 EOJSON
           @result = JSON.parse okapi "create /configurations/entries"
         end
-        @entry =  JSON.parse okapi "user:get /configurations/entries/#{@result["id"]}"
+        @entry =  JSON.parse okapi "get /configurations/entries/#{@result["id"]}"
       end
 
       it "stores the JSON" do
@@ -118,7 +118,7 @@ EOJSON
           okapi "destroy /configurations/entries/#{@result["id"]}"
         end
         it "no longer can be found as a resource" do
-          expect{okapi "user:get /configurations/#{@result["id"]}"}.to raise_error(Okapi::RequestError, /HTTPNotFound/)
+          expect{okapi "get /configurations/#{@result["id"]}"}.to raise_error(Okapi::RequestError, /HTTPNotFound/)
         end
       end
 


### PR DESCRIPTION
Two additional flags were added, `--no-tenant` and `--no-user`, to specifiy that a request should be made without a tenant or user token present in the request headers.

Also renamed `$ okapi get PATH` to `$ okapi show PATH` to be more inline with `create` and `destroy`.

```
$ okapi --no-tenant show /_/proxy/tenants
```