### PR TITLE
Let rubygems find the `okapi` executable.

### DIFF
--- a/okapi.gemspec
+++ b/okapi.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "clamp", "~> 1.1"


### PR DESCRIPTION
Out of the box, bundler creates the gemspec with the `./exe` as a place to look for executables so that it can install binstubs into your path. I suppose this change was made since technically these scripts like `./bin/okapi` aren't truly "binary" files in the sense of the word that was in place when most of the executables in the system were in fact compiled binaries.

As a result, when you install the `okapi` gem from rubygems, the cli at `bin/okapi` is not added to the path automatically.

However, the convention is to put executable stuff in a directory called `bin` even if it isn't binary, so we'll stick with that. and instead of telling rubygems to look for scripts in `./exe`, we tell it to go ahead and look in `./bin`