### PR TITLE
Don't require bundler to use okapi

### DIFF
--- a/bin/okapi
+++ b/bin/okapi
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-require 'bundler/setup'
-require 'okapi/cli'
 
+require 'okapi/cli'
 puts Okapi::CLI.run


### PR DESCRIPTION
```
$ gem install okapi
$ okapi --help
```

Should just work, but it doesn't because the `bin/` script requires bundler.

If you're hacking on this gem, you'll need to run

`bundle exec bin/okapi`