### PR TITLE
Add RubyGem badge to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Okapi
-
+[![Gem Version](https://badge.fury.io/rb/okapi.svg)](https://badge.fury.io/rb/okapi)
 [![Build Status](https://travis-ci.org/thefrontside/okapi.rb.svg?branch=master)](https://travis-ci.org/thefrontside/okapi.rb)
 
 ``` ruby


### PR DESCRIPTION
When you want to put a gem into your gemfile, it's helpful to have the version number handy rather than looking it up on the rubygems.org website or running `gem search GEMNAME`.

This puts the current version front and center at the top of the readme