### PR TITLE
Demonstrate that CLI prompts for input even without an OKAPI URL

### DIFF
--- a/spec/okapi_spec.rb
+++ b/spec/okapi_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe Okapi do
     end
   end
 
+  describe "trying to log in without having an okapi url or a tenant id configured" do
+    def no_stdin_allowed
+      $stdin = StringIO.new
+      yield
+    ensure
+      $stdin = STDIN
+    end
+    it "fails BEFORE you have to enter in your username and password" do
+      expect { no_stdin_allowed { okapi "login" }}.to raise_error(Okapi::ConfigurationError)
+    end
+  end
+
   describe "logging in" do
     def simulate_stdin_with(*args)
       $stdout = StringIO.new


### PR DESCRIPTION
If you don't have a URL configured for your OKAPI cluster, and you don't have a tenant configured either, then logging in is a non-starter, and prompting for input is pointless. As it stands, we create needless busy work for the users.

This demonstrates the CLI attempting to read console input from the user even when we know that the operation is doomed.

reproduces #15 