### PR TITLE
Prefetch url and tenant configuration params before logging in.

### DIFF
--- a/lib/okapi/cli.rb
+++ b/lib/okapi/cli.rb
@@ -44,6 +44,12 @@ module Okapi
 
     subcommand "login", "authenticate to okapi and store credentials" do
       def model
+        # We know that we're going to use these values
+        # so go ahead and pull them so that if they aren't
+        # set, they will throw a configuration error
+        client.settings.url
+        client.settings.tenant
+
         username = console.ask("username: ")
         password = console.ask("password: ") { |q| q.echo = "*" }
         client.tenant.post("/authn/login", username: username, password: password) do |json, response|

--- a/lib/okapi/settings.rb
+++ b/lib/okapi/settings.rb
@@ -7,10 +7,12 @@ module Okapi
     end
     def url
       get_var!(:url, <<~EOM) do |url|
-this operation requires the url of your Okapi gateway, but it couldn't be found.
+This operation requires the url of your Okapi gateway, but it couldn't be found.
 
 You can fix this by setting either the `OKAPI_URL` environment variable, or
 using the `--url` option if you're using the command line.
+
+To store a default url, run `okapi config:set OKAPI_URL=<URL>`
 EOM
         URI(url)
       end
@@ -18,21 +20,25 @@ EOM
 
     def tenant
       get_var!(:tenant, <<~EOM)
-this operation requires a tenant id, but it couldn't be found.
+This operation requires a tenant id, but it couldn't be found.
 
 You can fix this by setting either the `OKAPI_TENANT` environment variable, or
 using the `--tenant` option if you're using the command line.
+
+To store a default tenant, run `okapi config:set OKAPI_TENANT=<TENANT>`
 EOM
     end
 
     def token
       get_var!(:token, <<~EOM)
-this operation requires you to be logged in, and already authenticated with
+This operation requires you to be logged in, and already authenticated with
 your Okapi cluster.
 
 You can fix this by obtaining an authenication token, and then using it by
 either setting the `OKAPI_TOKEN` environment variable or using the
 `--token` option from the command line.
+
+To log in with a username and password, run the command `okapi login`.
 EOM
     end
 

--- a/spec/okapi_spec.rb
+++ b/spec/okapi_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe Okapi do
     end
   end
 
+  describe "trying to log in without having an okapi url or a tenant id configured" do
+    def no_stdin_allowed
+      $stdin = StringIO.new
+      yield
+    ensure
+      $stdin = STDIN
+    end
+    it "fails BEFORE you have to enter in your username and password" do
+      expect { no_stdin_allowed { okapi "login" }}.to raise_error(Okapi::ConfigurationError)
+    end
+  end
+
   describe "logging in" do
     def simulate_stdin_with(*args)
       $stdout = StringIO.new


### PR DESCRIPTION
If you don't have a URL configured for your OKAPI cluster, and you don't have a tenant configured either, then logging in is a non-starter, and prompting for input is pointless.

This accesses the `url` and `tenant` configuration parameters off of the `Okapi::Settings` object before the login process. These methods throw exceptions if the parameter is not present, so it will stop the process before bothering the user to enter in their username and password.

Also, the wording of the errors are updated to indicate that you can use environment variables, command line options OR persistent configuration variables to set your url and tenant.

## Before

![2017-11-21 10 46 19](https://user-images.githubusercontent.com/4205/33085290-ea3b781e-cea9-11e7-9cc6-1555a0497ad9.gif)

## After

![2017-11-21 10 49 19](https://user-images.githubusercontent.com/4205/33085297-ee4636ec-cea9-11e7-942b-13664b81d5ff.gif)

# Open Questions

Technically, you could still get some busy work because you could try and set your url, only to find that you need to set your tenant. This fix doesn't make you have to enter in your login credentials three times, but you still do need to run the login command three times. Is it worth trying to present the entirety of the configuration failure in one go?

resolves #15 #16 